### PR TITLE
Fix Bulb interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module git.sr.ht/~yoink00/tplight
+module github.com/cullenbass/tplight
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module git.sr.ht/~yoink00/tplight
+
+go 1.14


### PR DESCRIPTION
The `Bulb` interface's `Info()` function had the incorrect return value and the `NewBulb` function was returning a non-exported type instead of the `Bulb` interface.

A `go.mod` has been added to make gomodules happy and `go fmt` changes are included too.